### PR TITLE
[Setting] Nginx와 Certbot 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,23 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    depends_on:
+      - coanalysis-app
+    restart: always
+
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name newstailor.site www.newstailor.site; # 본인 도메인으로 수정
+
+    # SSL 인증을 위한 Certbot 경로
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # 기본적으로 HTTP로 오면 백엔드로 프록시
+    location / {
+        proxy_pass http://coanalysis-app:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
- docker-compose.yml에 nginx 및certbot비스 추가
- nginx를 리버스 프록시로 설정 (80, 443 포트)
- Let's Encrypt SSL 인증서 자동 갱신 설정
- newstailor.site 도메인 적용