### PR TITLE
[Fix] Gemini API 요청 간 4초 딜레이 추가

### DIFF
--- a/src/main/java/com/coanalysis/server/news/adapter/out/GeminiClient.java
+++ b/src/main/java/com/coanalysis/server/news/adapter/out/GeminiClient.java
@@ -61,6 +61,13 @@ public class GeminiClient {
         } catch (Exception e) {
             log.error("Gemini API 호출 실패: {}", e.getMessage());
             return null;
+        } finally {
+            // 분당 15건 제한 대응: 요청 후 무조건 4초 대기
+            try {
+                Thread.sleep(4000);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 


### PR DESCRIPTION
- 무료 티어 분당 15건 제한 대응 (60초 / 4초 = 15 RPM)
 - finally 블록에서 항상 4초 대기하여 429 사전 방지