### PR TITLE
[Fix] Gemini API 딜레이 4초 → 6초로 증가

### DIFF
--- a/src/main/java/com/coanalysis/server/news/adapter/out/GeminiClient.java
+++ b/src/main/java/com/coanalysis/server/news/adapter/out/GeminiClient.java
@@ -62,9 +62,9 @@ public class GeminiClient {
             log.error("Gemini API 호출 실패: {}", e.getMessage());
             return null;
         } finally {
-            // 분당 15건 제한 대응: 요청 후 무조건 4초 대기
+            // 분당 10건 기준 안전 대응: 요청 후 무조건 6초 대기
             try {
-                Thread.sleep(4000);
+                Thread.sleep(6000);
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
             }


### PR DESCRIPTION
- 실제 무료 티어 제한이 10 RPM일 수 있어 안전 마진 확보